### PR TITLE
Fix for 6537: Add filter to record list and site list

### DIFF
--- a/src/app/pages/data/list-datasets/list-datasets.component.html
+++ b/src/app/pages/data/list-datasets/list-datasets.component.html
@@ -6,13 +6,20 @@
         <div class="col-md">
             <h3>Datasets for {{project?.title}}</h3>
             <p>Select the dataset the records belong to</p>
-            <p-dataTable [value]="datasets" emptyMessage="No datasets found"[paginator]="true" [rows]="15" [responsive]="true">
-                <p-column field="name" header="Name" [sortable]="true" [filter]="true">
+            <p-dataTable [value]="datasets" emptyMessage="No datasets found" [paginator]="true" [rows]="15"
+                         [globalFilter]="datasetSearch" [responsive]="true">
+                <p-header>
+                    <div class="ui-helper-clearfix" style="width:100%">
+                        <i class="fa fa-search float-left mt-1 mr-1"></i>
+                        <input #datasetSearch type="text" class="float-left" pInputText placeholder="Search">
+                    </div>
+                </p-header>
+                <p-column field="name" header="Name" [sortable]="true">
                     <ng-template let-dataset="rowData" pTemplate="body">
                         <a [routerLink]="'/data/projects/' + project?.id + '/datasets/' + dataset.id">{{dataset.name}}</a>
                     </ng-template>
                 </p-column>
-                <p-column field="type" header="Type" [sortable]="true" [filter]="true">
+                <p-column field="type" header="Type" [sortable]="true">
                     <ng-template let-dataset="rowData" pTemplate="body">
                         {{DATASET_TYPE_MAP[dataset.type]}}
                     </ng-template>

--- a/src/app/pages/data/list-projects/list-projects.component.html
+++ b/src/app/pages/data/list-projects/list-projects.component.html
@@ -7,13 +7,19 @@
             <h3>Projects</h3>
             <p>Select a project to view available datasets to create / edit / delete records for</p>
             <p-dataTable [value]="projects" emptyMessage="No projects found" [paginator]="true" [rows]="15"
-                         [responsive]="true">
-                <p-column field="title" header="Title" [sortable]="true" [filter]="true">
+                         [globalFilter]="projectSearch" [responsive]="true">
+                <p-header>
+                    <div class="ui-helper-clearfix" style="width:100%">
+                        <i class="fa fa-search float-left mt-1 mr-1"></i>
+                        <input #projectSearch type="text" class="float-left" pInputText placeholder="Search">
+                    </div>
+                </p-header>
+                <p-column field="title" header="Title" [sortable]="true">
                     <ng-template let-project="rowData" pTemplate="body">
                         <a class="table-link" [routerLink]="'/data/projects/' + project.id + '/datasets'">{{project.title}}</a>
                     </ng-template>
                 </p-column>
-                <p-column field="code" header="Code" [sortable]="true" [filter]="true"></p-column>
+                <p-column field="code" header="Code" [sortable]="true"></p-column>
                 <!--<p-column header="Custodians" [sortable]="true" [filter]="true"></p-column>-->
             </p-dataTable>
         </div>

--- a/src/app/pages/data/manage-data/manage-data.component.html
+++ b/src/app/pages/data/manage-data/manage-data.component.html
@@ -8,17 +8,23 @@
             <h3>Records for {{dataset?.name}}</h3>
             <p>Select a particular record to edit or click Add to add a new record</p>
             <div class="data-table-container">
-                <p-dataTable [tableStyle]="getDataTableWidth()" [value]="records" [emptyMessage]="tablePlaceholder"
-                             [paginator]="true" [rows]="10" [responsive]="true">
-                    <p-column header="Record ID" [sortable]="true">
-                        <ng-template let-record="rowData" pTemplate="body">
-                            <a class="table-link" [routerLink]="'/data/projects/' + projId + '/datasets/' + datasetId + '/record/' + record.id">{{record.id}}</a>
+                <p-dataTable [tableStyle]="getDataTableWidth()" [value]="getRecordsData()" [emptyMessage]="tablePlaceholder"
+                             [paginator]="true" [rows]="10" [globalFilter]="recordSearch" [responsive]="true">
+                    <p-header>
+                        <div class="ui-helper-clearfix" style="width:100%">
+                            <i class="fa fa-search float-left mt-1 mr-1"></i>
+                            <input #recordSearch type="text" class="float-left" pInputText placeholder="Search">
+                        </div>
+                    </p-header>
+                    <p-column field="id" header="Record ID" [sortable]="true">
+                        <ng-template let-data="rowData" pTemplate="body">
+                            <a class="table-link" [routerLink]="'/data/projects/' + projId + '/datasets/' + datasetId + '/record/' + data.recordId">{{data.recordId}}</a>
                         </ng-template>
                     </p-column>
                     <p-column *ngFor="let field of dataset?.data_package?.resources[0]?.schema?.fields"
                               [field]="field.name" [header]="field.name" [sortable]="true">
-                        <ng-template let-record="rowData" let-col pTemplate="body">
-                            <span [innerHTML]="record.data[col.field] | truncate:30"></span>
+                        <ng-template let-data="rowData" let-col pTemplate="body">
+                            <span [innerHTML]="data[col.field] | truncate:30"></span>
                         </ng-template>
                     </p-column>
                     <p-footer>

--- a/src/app/pages/data/manage-data/manage-data.component.html
+++ b/src/app/pages/data/manage-data/manage-data.component.html
@@ -9,7 +9,7 @@
             <p>Select a particular record to edit or click Add to add a new record</p>
             <div class="data-table-container">
                 <p-dataTable [tableStyle]="getDataTableWidth()" [value]="getRecordsData()" [emptyMessage]="tablePlaceholder"
-                             [paginator]="true" [rows]="10" [globalFilter]="recordSearch" [responsive]="true">
+                             [paginator]="true" [rows]="10" [globalFilter]="recordSearch">
                     <p-header>
                         <div class="ui-helper-clearfix" style="width:100%">
                             <i class="fa fa-search float-left mt-1 mr-1"></i>

--- a/src/app/pages/data/manage-data/manage-data.component.ts
+++ b/src/app/pages/data/manage-data/manage-data.component.ts
@@ -109,6 +109,10 @@ export class ManageDataComponent implements OnInit {
         }
     }
 
+    public getRecordsData(): any[] {
+        return this.records.map((r) => Object.assign({recordId: r.id}, r.data));
+    }
+
     public add() {
         this.router.navigate(['/data/projects/' + this.projId + '/datasets/' + this.datasetId + '/create-record/']);
     }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -63,6 +63,12 @@ export class HomeComponent implements OnInit {
             if(project.centroid) {
                 let marker = L.geoJSON(project.centroid).addTo(this.map);
                 marker.bindPopup(project.title);
+                marker.on('mouseover', function (e) {
+                    this.openPopup();
+                });
+                marker.on('mouseout', function (e) {
+                    this.closePopup();
+                });
                 marker.addTo(this.map);
             }
         }

--- a/src/app/pages/management/edit-project/edit-project.component.html
+++ b/src/app/pages/management/edit-project/edit-project.component.html
@@ -94,13 +94,19 @@
     <div *ngIf="project.id" class="row mt-1">
         <div class="col-md">
             <h4>Datasets</h4>
-            <p-dataTable [value]="datasets" [paginator]="true" [rows]="10" [responsive]="true">
-                <p-column header="Name">
+            <p-dataTable [value]="datasets" [globalFilter]="datasetSearch" [paginator]="true" [rows]="10" [responsive]="true">
+                <p-header>
+                    <div class="ui-helper-clearfix" style="width:100%">
+                        <i class="fa fa-search float-left mt-1 mr-1"></i>
+                        <input #datasetSearch type="text" class="float-left" pInputText placeholder="Search">
+                    </div>
+                </p-header>
+                <p-column field="name" header="Name">
                     <ng-template let-dataset="rowData" pTemplate="body">
                         <a [routerLink]="'/management/projects/edit-project/' + project.id + '/edit-dataset/' + dataset.id">{{dataset.name}}</a>
                     </ng-template>
                 </p-column>
-                <p-column header="Type">
+                <p-column field="type" header="Type">
                     <ng-template let-dataset="rowData" pTemplate="body">
                         {{DATASET_TYPE_MAP[dataset.type]}}
                     </ng-template>
@@ -126,8 +132,14 @@
     <div *ngIf="project.id" class="row mt-3 mb-3">
         <div class="col-md">
             <h4>Sites</h4>
-            <p-dataTable [value]="sites" [paginator]="true" [rows]="10" [responsive]="true">
-                <p-column header="Code">
+            <p-dataTable [value]="sites" [globalFilter]="siteSearch" [paginator]="true" [rows]="10" [responsive]="true">
+                <p-header>
+                    <div class="ui-helper-clearfix" style="width:100%">
+                        <i class="fa fa-search float-left mt-1 mr-1"></i>
+                        <input #siteSearch type="text" class="float-left" pInputText placeholder="Search">
+                    </div>
+                </p-header>
+                <p-column field="code" header="Code">
                     <ng-template let-site="rowData" pTemplate="body">
                         <a [routerLink]="'/management/projects/edit-project/' + project.id + '/edit-site/' + site.id">{{site.code}}</a>
                     </ng-template>

--- a/src/app/pages/management/edit-project/edit-project.component.html
+++ b/src/app/pages/management/edit-project/edit-project.component.html
@@ -82,7 +82,7 @@
                 <div class="col-md-6">
                     <label>Extent</label>
                     <div>
-                        <biosys-featuremap [isEditing]="isEditing" [geometry]="project.geometry" [drawFeatureTypes]="['POLYGON']">
+                        <biosys-featuremap [isEditing]="isEditing" [geometry]="project.geometry" [drawFeatureTypes]="['POLYGON', 'LINE']">
                             <biosys-marker *ngFor="let site of sites" [geometry]="site.centroid" [popupText]="site.name ? site.name : site.code"></biosys-marker>
                         </biosys-featuremap>
                     </div>

--- a/src/app/pages/management/list-projects/list-projects.component.html
+++ b/src/app/pages/management/list-projects/list-projects.component.html
@@ -7,7 +7,13 @@
         <div class="col-md">
             <h3>Projects</h3>
             <p>Select a project to edit or delete or click add to create a new project</p>
-            <p-dataTable [value]="projects" [paginator]="true" [rows]="15" [responsive]="true">
+            <p-dataTable [value]="projects" [globalFilter]="projectSearch" [paginator]="true" [rows]="15" [responsive]="true">
+                <p-header>
+                    <div class="ui-helper-clearfix" style="width:100%">
+                        <i class="fa fa-search float-left mt-1 mr-1"></i>
+                        <input #projectSearch type="text" class="float-left" pInputText placeholder="Search">
+                    </div>
+                </p-header>
                 <p-column field="title" header="Title" [sortable]="true">
                     <ng-template let-project="rowData" pTemplate="body">
                         <a class="table-link" [routerLink]="'/management/projects/edit-project/' + project.id">{{project.title}}</a>

--- a/src/app/shared/featuremap/featuremap.component.ts
+++ b/src/app/shared/featuremap/featuremap.component.ts
@@ -29,6 +29,12 @@ export class FeatureMapComponent implements OnInit, OnChanges {
                 let coord: GeoJSON.Position = marker.geometry.coordinates as GeoJSON.Position;
                 let leafletMarker: L.Marker = L.marker(L.GeoJSON.coordsToLatLng([coord[0], coord[1]]), {icon: this.icon});
                 leafletMarker.bindPopup(marker.popupText);
+                leafletMarker.on('mouseover', function (e) {
+                    this.openPopup();
+                });
+                leafletMarker.on('mouseout', function (e) {
+                    this.closePopup();
+                });
                 this.map.addLayer(leafletMarker);
             }
         });


### PR DESCRIPTION
Using global filter for all filterable tables, rather than per-column filters.

All tables except in View/Export now have global filters.

Needed to do a bit of reconfiguration to get filtering working on records table.

Project extent can now be a line.

Markers now showing popups on hover.