### PR TITLE
Disable ace for jsoneditor

### DIFF
--- a/config/project.config.ts
+++ b/config/project.config.ts
@@ -363,7 +363,7 @@ export class ProjectConfig {
                 'node_modules/@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
             '@angular/router/testing': 'node_modules/@angular/router/bundles/router-testing.umd.js',
             'primeng': 'node_modules/primeng',
-            'jsoneditor': 'node_modules/jsoneditor/dist/jsoneditor.js',
+            'jsoneditor': 'node_modules/jsoneditor/dist/jsoneditor-minimalist.js',
             'leaflet': 'node_modules/leaflet/dist/leaflet.js',
             'leaflet-draw': 'node_modules/leaflet-draw/dist/leaflet.draw.js',
             'moment': 'node_modules/moment/moment.js',
@@ -403,7 +403,7 @@ export class ProjectConfig {
         ],
         paths: {
             'css': 'node_modules/systemjs-plugin-css/css.js',
-            'jsoneditor': 'node_modules/jsoneditor/dist/jsoneditor.js',
+            'jsoneditor': 'node_modules/jsoneditor/dist/jsoneditor-minimalist.js',
             [join(this.TMP_DIR, this.BOOTSTRAP_DIR, '*')]: `${this.TMP_DIR}/${this.BOOTSTRAP_DIR}/*`,
             '@angular/platform-browser/animations': 'node_modules/@angular/platform-browser/bundles/platform-browser-animations.umd.js',
             '@angular/animations/browser': 'node_modules/@angular/animations/bundles/animations-browser.umd.js',
@@ -466,7 +466,6 @@ export class ProjectConfig {
                 defaultExtension: 'js'
             },
             'jsoneditor': {
-                main: 'jsoneditor.js',
                 defaultExtension: 'js',
                 format: 'global'
             }

--- a/src/app/pages/management/edit-dataset/edit-dataset.component.ts
+++ b/src/app/pages/management/edit-dataset/edit-dataset.component.ts
@@ -31,8 +31,8 @@ export class EditDatasetComponent implements OnInit {
                 private router: Router,
                 private route: ActivatedRoute) {
         this.editorOptions = new JsonEditorOptions();
-        this.editorOptions.mode = 'code';
-        this.editorOptions.modes = ['code', 'form', 'text', 'tree', 'view'];
+        this.editorOptions.mode = 'text';
+        this.editorOptions.modes = ['form', 'text', 'tree', 'view'];
         this.editorOptions.onChange = this.onEditorChanged.bind(this);
     }
 

--- a/src/app/shared/jsoneditor/jsoneditor.component.ts
+++ b/src/app/shared/jsoneditor/jsoneditor.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ElementRef, Input } from '@angular/core';
 
 import { JsonEditorOptions } from './jsoneditor.options';
 
-// declare var editor: any;
+// TODO: why the jsoneditor with ace breaks when bundled. Also the css can't find the icons.svg file
 let JSONEditor = require('jsoneditor');
 
 import 'jsoneditor/dist/jsoneditor.min.css';


### PR DESCRIPTION
jsoneditor with ace (color +validation) breaks when bundled.  
Use the minimalist version and disable the `code` mode.
